### PR TITLE
Add color support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,19 @@
 	},
 	"dependencies": {
 		"vsce": "^1.36.2"
+	},
+	"contributes": {
+		"configuration":[
+			{
+				"type": "object",
+				"title": "code-eol Configuration",
+				"properties": {
+					"code-eol.color": {
+						"type": ["string", "null"],
+						"default": null
+					}
+				}
+			}
+		]
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,8 @@ export function activate (context: vscode.ExtensionContext) {
     if (!activeEditor) {
       return
     }
+    const configuration = vscode.workspace.getConfiguration('code-eol')
+    const decorationColor = configuration.color
     const regEx = /(\r(?!\n))|(\r?\n)/g
     const text = activeEditor.document.getText()
     const newLines: vscode.DecorationOptions[] = []
@@ -43,7 +45,12 @@ export function activate (context: vscode.ExtensionContext) {
       const endPos = activeEditor.document.positionAt(match.index + 1)
       const decoration: vscode.DecorationOptions = {
         range: new vscode.Range(startPos, endPos),
-        renderOptions: { before: { contentText: decTxt } }
+        renderOptions: { 
+          before: {
+            contentText: decTxt,
+            color: decorationColor
+          }
+        }
       }
       newLines.push(decoration)
     }


### PR DESCRIPTION
This adds simple color configuration. You can place this in your `settings.json` file now.

`"code-eol.color": "#FF0000"`

If unspecified, it will continue to use the theme value.